### PR TITLE
Fix GET content-length handling

### DIFF
--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -6,7 +6,10 @@ Compatibility code to be able to use `cookielib.CookieJar` with requests.
 requests.utils imports from here, so be careful with imports.
 """
 
-import collections
+try:
+    from collections.abc import MutableMapping
+except ImportError:  # Python 2 fallback
+    from collections import MutableMapping
 from .compat import cookielib, urlparse, Morsel
 
 try:
@@ -133,7 +136,7 @@ class CookieConflictError(RuntimeError):
     Use .get and .set and include domain and path args in order to be more specific."""
 
 
-class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
+class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
     """Compatibility class; is a cookielib.CookieJar, but exposes a dict interface.
 
     This is the CookieJar we create by default for requests and sessions that

--- a/requests/models.py
+++ b/requests/models.py
@@ -137,10 +137,15 @@ class RequestHooksMixin(object):
     def register_hook(self, event, hook):
         """Properly register a hook."""
 
-        if isinstance(hook, collections.Callable):
+        try:
+            from collections.abc import Callable
+        except ImportError:  # Python 2 fallback
+            from collections import Callable
+
+        if isinstance(hook, Callable):
             self.hooks[event].append(hook)
         elif hasattr(hook, '__iter__'):
-            self.hooks[event].extend(h for h in hook if isinstance(h, collections.Callable))
+            self.hooks[event].extend(h for h in hook if isinstance(h, Callable))
 
     def deregister_hook(self, event, hook):
         """Deregister a previously registered hook.
@@ -386,12 +391,26 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         self.body = body
 
     def prepare_content_length(self, body):
-        self.headers['Content-Length'] = '0'
+        """Add or remove Content-Length header as appropriate."""
+
+        if body is None:
+            # No body to send; don't set a Content-Length header unless the
+            # user has explicitly provided one.
+            if 'Content-Length' in self.headers:
+                # Respect explicit header by leaving it as-is
+                return
+            self.headers.pop('Content-Length', None)
+            return
+
+        if 'Content-Length' in self.headers:
+            # Assume the user has set it deliberately.  Do not modify.
+            return
+
         if hasattr(body, 'seek') and hasattr(body, 'tell'):
             body.seek(0, 2)
             self.headers['Content-Length'] = str(body.tell())
             body.seek(0, 0)
-        elif body is not None:
+        else:
             self.headers['Content-Length'] = str(len(body))
 
     def prepare_auth(self, auth):

--- a/requests/packages/urllib3/_collections.py
+++ b/requests/packages/urllib3/_collections.py
@@ -4,7 +4,10 @@
 # This module is part of urllib3 and is released under
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 
-from collections import MutableMapping
+try:
+    from collections.abc import MutableMapping
+except ImportError:  # Python 2 fallback
+    from collections import MutableMapping
 from threading import Lock
 
 try: # Python 2.7+

--- a/test_requests.py
+++ b/test_requests.py
@@ -73,6 +73,10 @@ class RequestsTestCase(unittest.TestCase):
         self.assertEqual(request.url,
             "http://example.com/path?key=value&a=b#fragment")
 
+    def test_content_length_header_not_added_for_get(self):
+        request = requests.Request('GET', "http://example.com/").prepare()
+        self.assertTrue('Content-Length' not in request.headers)
+
     def test_HTTP_200_OK_GET_ALTERNATIVE(self):
         r = requests.Request('GET', httpbin('get'))
         s = requests.Session()


### PR DESCRIPTION
## Summary
- don't set content-length on GET requests with no body
- update tests to cover missing header
- modernize imports for Python 3.11
- avoid overriding user-provided hooks with deprecated collections APIs

## Testing
- `python test_requests.py -v` *(fails: HTTPConnection.__init__() got an unexpected keyword argument 'strict')*